### PR TITLE
Add namespace support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Quickstart
         address = TextProperty(default='blah')
         te = ListProperty(ReferenceProperty(TestEntity))
 
-    connect('dataset_id')
+    connect(dataset_id='dataset_id', namespace='demo')
 
     es = TestEntity.objects.filter(name='Alice')
     oe = OtherTestEntity(te=[e for e in es])

--- a/gcloudoem/datastore/__init__.py
+++ b/gcloudoem/datastore/__init__.py
@@ -2,7 +2,7 @@
 # Author: Ryan Stuart<ryan@kapiche.com>
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from .connection import ConnectionError, Connection, register_connection, DEFAULT_CONNECTION_NAME
+from .connection import ConnectionError, Connection, register_connection, DEFAULT_NAMESPACE
 from .environment import determine_default_dataset_id
 from gcloudoem.datastore import credentials
 
@@ -11,10 +11,12 @@ SCOPE = ('https://www.googleapis.com/auth/datastore', 'https://www.googleapis.co
 """The scopes required for authenticating as a Cloud Datastore consumer."""
 
 
-def connect(dataset_id=None):
+def connect(dataset_id=None, namespace=DEFAULT_NAMESPACE):
     """
-    Connect to Datastore dataset. If no dataset is given, we attempt to determine it given the environment.
+    Connect to Datastore. If no dataset is given, we attempt to determine it given the environment.
 
+    :param namespace: The namespace to use. A namespace is used for multi-tenancy on datastore. It's useful for
+        separating dev data from production data for example.
     :param str dataset_id: Optional. The dataset ID to use as default.
     """
     if dataset_id is None:
@@ -23,4 +25,4 @@ def connect(dataset_id=None):
             raise ConnectionError("Couldn't determine the dataset id from the environment")
     implicit_credentials = credentials.get_credentials()
     scoped_credentials = implicit_credentials.create_scoped(SCOPE)
-    register_connection(DEFAULT_CONNECTION_NAME, dataset_id, scoped_credentials)
+    register_connection(dataset_id, namespace, scoped_credentials)

--- a/gcloudoem/datastore/base.py
+++ b/gcloudoem/datastore/base.py
@@ -57,10 +57,13 @@ class BaseConnection(object):
     USER_AGENT = "gcloud-datastore-oem"
     """The user agent for requests."""
 
-    def __init__(self, dataset, credentials=None, http=None):
+    def __init__(self, dataset, namespace, credentials=None, http=None):
         """
         :type dataset: str
         :param dataset: The gcloud Datastore dataset identifier.
+
+        :type namespace: str
+        :param namespace: The gcloud Datastore namespace to use.
 
         :type credentials: :class:`oauth2client.client.OAuth2Credentials` or :class:`NoneType`
         :param credentials: The OAuth2 Credentials to use for this connection.
@@ -69,12 +72,17 @@ class BaseConnection(object):
         :param http: An optional HTTP object to make requests.
         """
         self._dataset = dataset
+        self._namespace = namespace
         self._http = http
         self._credentials = credentials
 
     @property
     def dataset(self):
         return self._dataset
+
+    @property
+    def namespace(self):
+        return self._namespace
 
     @property
     def credentials(self):

--- a/gcloudoem/datastore/query.py
+++ b/gcloudoem/datastore/query.py
@@ -53,15 +53,13 @@ class Query(object):
     }
     """Mapping of operator strs and their protobuf equivalents."""
 
-    def __init__(self, entity, namespace=None, ancestor=None, filters=(), projection=(), order=(), group_by=(),
+    def __init__(self, entity, ancestor=None, filters=(), projection=(), order=(), group_by=(),
                  limit=None, offset=0):
         """
         Initialise a new Query.
 
         :type entity: type
         :param entity: The entity class to use for the query. Used to derive the ``kind`` passed to datastore.
-
-        :param str namespace: The namespace to which to restrict results (optional).
 
         :type ancestor: :class:`~gcloudoem.entity.Entity` or None
         :param ancestor: the ancestor to which this query's results are restricted.
@@ -84,9 +82,6 @@ class Query(object):
 
         :type offset: int
         :param offset: the offset into the results the first entity should be. Defaults to 0.
-
-        :raises :class:`~gcloudoem.exceptions.EnvironmentError`: If you aren't connected to datastore (and hence there
-            is no dataset_id).
         """
         from gcloudoem import Entity
 
@@ -94,7 +89,6 @@ class Query(object):
             raise ValueError('You must pass a valid entity class to query (one that subclasses Entity)')
 
         self._entity = entity
-        self._namespace = namespace
         self._ancestor = ancestor
         self._filters = list(filters)
         self._projection = list(projection)
@@ -128,26 +122,6 @@ class Query(object):
     def is_limited(self):
         """Has an offset or limit been applied to this query?"""
         return bool(self._offset or self._limit)
-
-    @property
-    def namespace(self):
-        """
-        This query's namespace
-
-        :rtype: str or None
-        """
-        return self._namespace
-
-    @namespace.setter
-    def namespace(self, value):
-        """
-        Update the query's namespace.
-
-        :type value: str
-        """
-        if not isinstance(value, six.text_type):
-            raise ValueError("Namespace must be a str")
-        self._namespace = value
 
     @property
     def entity(self):
@@ -354,7 +328,7 @@ class Query(object):
 
     def clone(self):
         return self.__class__(
-            self._entity, self._namespace, self._ancestor, self.filters, self.projection, self.order, self.group_by,
+            self._entity, self._ancestor, self.filters, self.projection, self.order, self.group_by,
             self._limit, self._offset
         )
 
@@ -472,7 +446,7 @@ class Cursor(object):
 
         query_results = self._connection.run_query(
             query_pb=pb,
-            namespace=self._query.namespace,
+            namespace=self._connection.namespace,
             transaction_id=transaction and transaction.id,
         )
         # NOTE: `query_results` contains an extra value that we don't use, namely `skipped_results`.

--- a/gcloudoem/properties.py
+++ b/gcloudoem/properties.py
@@ -108,6 +108,7 @@ class KeyProperty(BaseProperty):
         if not dataset_id:
             raise EnvironmentError("Couldn't determine the dataset ID. Have you called connect?")
         key.partition_id.dataset_id = dataset_id
+        key.partition_id.namespace = get_connection().namespace
 
         for item in value.path:
             element = key.path_element.add()

--- a/tests/datastore/test_connection.py
+++ b/tests/datastore/test_connection.py
@@ -32,6 +32,7 @@ from gcloudoem.datastore.connection import disconnect
 
 class TestConnection(unittest2.TestCase):
     DATASET = 'DATASET'
+    NAMESPACE = 'TEST'
 
     @classmethod
     def setUpClass(cls):
@@ -58,7 +59,7 @@ class TestConnection(unittest2.TestCase):
         return pb
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(self.DATASET, *args, **kw)
+        return self._getTargetClass()(self.DATASET, self.NAMESPACE, *args, **kw)
 
     def _verifyProtobufCall(self, called_with, URI, conn):
         self.assertEqual(called_with['uri'], URI)

--- a/tests/datastore/test_transaction.py
+++ b/tests/datastore/test_transaction.py
@@ -136,6 +136,7 @@ class TestTransaction(unittest2.TestCase):
     def test_txn_commit_w_auto_ids(self):
         connection = MagicMock(spec=Connection)
         connection.dataset = 'DATASET'
+        connection.namespace = 'TEST'
         with patch('gcloudoem.properties.get_connection', return_value=connection):
             resp = datastore_pb.CommitResponse()
             resp.mutation_result.insert_auto_id_key.extend([self._make_key_pb()])


### PR DESCRIPTION
This allows us to mimic multiple databases by using the namespace to
separate data.

Closes #2.